### PR TITLE
Use static UID/GID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,6 @@ RUN wget https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.14.0/cy
 RUN chmod +x /bin/cyclonedx
 COPY . .
 RUN yarn install
+USER 10000:10001
 # Assume that project root is mounted at /src
 ENTRYPOINT ["/opt/jupiterone/bin/node-cdx-bom", "/src"]


### PR DESCRIPTION
This is also a bump to force docker rebuild/publish.