### PR TITLE
fix: Fixing metadata.component being clobbered

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update
 # CYCLONEDX
 # Keep an eye out for releases of cyclonedx
 # We might need to bump a version when necessary
-RUN wget https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.19.0/cyclonedx-linux-x64 -O /bin/cyclonedx
+RUN wget https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-linux-x64 -O /bin/cyclonedx
 RUN chmod +x /bin/cyclonedx
 
 COPY . .


### PR DESCRIPTION
metadata.component is being clobbered when running a merge. This was fixed in 0.24.2 based on the following issue

https://github.com/CycloneDX/cyclonedx-cli/issues/218