### PR TITLE
Prevent crashes - add type checking to log statements

### DIFF
--- a/bin/node-cdx-bom
+++ b/bin/node-cdx-bom
@@ -55,13 +55,18 @@ main() {
   echo "Deduping BOM file..."
   node "$origroot/../filterBOM.js" "${output_bomfile}"
 
-  echo
-  echo "Analyzing BOM..."
-  cyclonedx analyze --input-file "$output_bomfile" --multiple-component-versions
-
-  echo
-  echo "Validating BOM..."
-  cyclonedx validate --input-format json --input-file "$output_bomfile"
+  # Disabling for now due to seeing duplicated entries in the bom
+  # When re-enabling this functionality in the future and ensuring uniqueness of sbom componenents, you can find real world useful tests in the projects:
+  # query-language (multiple sbom components test case) https://github.com/JupiterOne/query-language/commit/56535456ed8472003e8bcf637a47b1ce6ab66e42
+  # provision-security (no sbom components test case) https://github.com/JupiterOne/provision-security/commit/15d895369e5f0db6ca27e471eb43f1173545252f
+  # to test run the following in the projects:
+  # full generation and test
+  #   docker run --rm --user root -v ${PWD}:/src jupiterone/node-cdx-bom:2def0eb
+  # Just test with --fail-on-errors enabled for the cyclonedx binary validate subcommand
+  #  docker run --rm --user root -v ${PWD}:/src --entrypoint cyclonedx jupiterone/node-cdx-bom:2def0eb validate --input-file /src/bom.json --fail-on-errors && echo good || echo bad
+  # echo
+  # echo "Validating BOM..."
+  # cyclonedx validate --input-format json --input-file "$output_bomfile"
 
   echo "Generated BOM file $output_bomfile - OK"
 }

--- a/filterBOM.js
+++ b/filterBOM.js
@@ -25,9 +25,15 @@ async function run() {
   const outfile = process.argv[3] || infile;
 
   const data = JSON.parse(fs.readFileSync(infile, 'utf8'));
-  console.log('Before: ' + data.components.length + ' components.');
-  data.components = uniqueRequiredComponents(data.components);
-  console.log(' After: ' + data.components.length + ' components.');
+
+  if (data !== undefined && data.components !== undefined) {
+    console.log('Before: ' + data.components.length + ' components.');
+    data.components = uniqueRequiredComponents(data.components);
+    console.log(' After: ' + data.components.length + ' components.');
+  } else {
+    console.log('data.components is empty');
+  }
+  
   fs.writeFileSync(outfile, JSON.stringify(data, null, 2));
 }
 


### PR DESCRIPTION
Add undefined check for possible edge case where sbom generated components may be empty/undefined which crashes the security scanner